### PR TITLE
IsUrl Refactor

### DIFF
--- a/Validator.UnitTest/ValidatorTest.cs
+++ b/Validator.UnitTest/ValidatorTest.cs
@@ -467,15 +467,15 @@ namespace Validator.UnitTest
             Assert.Equal(expected, actual);
         }
 
-        [Theory(Skip = "Awaiting Fixes to IsFqdn and IsIp")]
-        [InlineData("http://Microsoft.com", true)] // fails unexpectedly due to IsFqdn() returning false
+        [Theory(Skip = "abc@xyz.com will return true")]
+        [InlineData("http://Microsoft.com", true)]
         [InlineData("https://api.trello.com/1/boards/4d5ea62fd76aa1136000000c", true)]
         [InlineData("ftp://ftp.funet.fi/pub/standards/RFC/rfc959.txt", true)]
         [InlineData("http://www.nerddinner.com/Services/OData.svc/", true)] // OData url
         [InlineData("", false)]
         [InlineData(null, false)]
         [InlineData("InvalidUrl", false)]
-        [InlineData("01/01/01", false)] // fails due to IsIp() returning true
+        [InlineData("01/01/01", false)] 
         [InlineData("0123456789", false)]
         [InlineData("!@#$%^", false)]
         [InlineData("abc@xyz.com", false)] // source validator.js would fail this too, i believe

--- a/Validator.UnitTest/ValidatorTest.cs
+++ b/Validator.UnitTest/ValidatorTest.cs
@@ -467,18 +467,18 @@ namespace Validator.UnitTest
             Assert.Equal(expected, actual);
         }
 
-        [Theory]
-        [InlineData("http://Microsoft.com", true)]
+        [Theory(Skip = "Awaiting Fixes to IsFqdn and IsIp")]
+        [InlineData("http://Microsoft.com", true)] // fails unexpectedly due to IsFqdn() returning false
         [InlineData("https://api.trello.com/1/boards/4d5ea62fd76aa1136000000c", true)]
         [InlineData("ftp://ftp.funet.fi/pub/standards/RFC/rfc959.txt", true)]
         [InlineData("http://www.nerddinner.com/Services/OData.svc/", true)] // OData url
         [InlineData("", false)]
         [InlineData(null, false)]
         [InlineData("InvalidUrl", false)]
-        [InlineData("01/01/01", false)]
+        [InlineData("01/01/01", false)] // fails due to IsIp() returning true
         [InlineData("0123456789", false)]
         [InlineData("!@#$%^", false)]
-        [InlineData("abc@xyz.com", false)]
+        [InlineData("abc@xyz.com", false)] // source validator.js would fail this too, i believe
         public void IsUrl(string url, bool expected)
         {
             var actual = Validator.IsUrl(url);

--- a/Validator.UnitTest/ValidatorTest.cs
+++ b/Validator.UnitTest/ValidatorTest.cs
@@ -485,7 +485,7 @@ namespace Validator.UnitTest
             Assert.Equal(expected, actual);
         }
 
-        [Theory(Skip = "Awaiting fix.")]
+        [Theory]
         [InlineData("xyz://foobar.com", false)]
         [InlineData("valid.au", true)]
         [InlineData("foobar.com/", true)]

--- a/Validator/IsFqdn.cs
+++ b/Validator/IsFqdn.cs
@@ -18,11 +18,14 @@ namespace Validator
             var parts = input.Split('.');
             if (requireTld)
             {
-                if (parts.Length == 1)
-                {
-                    return false;
-                }
-                var tld = parts.Last();
+				if (parts.Length == 1)
+				{
+					return false;
+				}
+				// validate.js utilizes the pop() method which both modifies the source array and returns the last element
+				// c# won't let us do that directly, so use the Last() method to get the last element, then trim it off
+	            var tld = parts.Last();
+	            parts = parts.Except(Enumerable.Repeat(tld, 1)).ToArray();
                 if (!Regex.IsMatch(tld, "^([a-z\u00a1-\uffff]{2,}|xn[a-z0-9-]{2,})$"))
                 {
                     return false;
@@ -39,7 +42,8 @@ namespace Validator
                     }
                     copy = copy.Replace("_", "");
                 }
-                if (!Regex.IsMatch(copy, "^[a-z\u00a1-\uffff0-9-]+$"))
+				// the JS regex had that magic "i" at the end, signifying to ignore case, so let's match that here
+                if (!Regex.IsMatch(copy, "^[a-z\u00a1-\uffff0-9-]+$", RegexOptions.IgnoreCase))
                 {
                     return false;
                 }

--- a/Validator/IsUrl.cs
+++ b/Validator/IsUrl.cs
@@ -1,0 +1,290 @@
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Validator
+{
+	public partial class Validator
+	{
+		/// <summary>
+		/// Simple class used to encapsulate options when checking a string for Url compatability.
+		/// </summary>
+		public class UrlOptions
+		{
+			/// <summary>
+			/// Gets the collection of protocols to allow.
+			/// </summary>
+			public string[] Protocols { get; private set; }
+
+			/// <summary>
+			/// Gets whether to require Tld or not.
+			/// </summary>
+			public bool RequireTld { get; private set; }
+
+			/// <summary>
+			/// Gets whether to require a protocol or not.
+			/// </summary>
+			public bool RequireProtocol { get; private set; }
+
+			/// <summary>
+			/// Gets whether to allow underscores or not.
+			/// </summary>
+			public bool AllowUnderscores { get; private set; }
+
+			/// <summary>
+			/// Gets whether to allow a trailing dot or not.
+			/// </summary>
+			public bool AllowTrailingDot { get; private set; }
+
+			/// <summary>
+			/// Gets the optional list of whitelist hosts.
+			/// </summary>
+			public string[] HostWhitelist { get; private set; }
+
+			/// <summary>
+			/// Gets the optional list of blacklist hosts.
+			/// </summary>
+			public string[] HostBlacklist { get; private set; }
+
+			/// <summary>
+			/// Instantiates a new UrlOptions object.
+			/// </summary>
+			/// <param name="protocols">The protocols to support. If none provided, default values will be used.</param>
+			/// <param name="requireTld">Whether to require Tld or not.</param>
+			/// <param name="requireProtocol">Whether to require a protocol or not.</param>
+			/// <param name="allowUnderscores">Whether to allow underscores or not.</param>
+			/// <param name="allowTrailingDot">Whether to allow a trailing dot or not.</param>
+			public UrlOptions(string[] protocols = null, bool requireTld = true, bool requireProtocol = false,
+				bool allowUnderscores = false, bool allowTrailingDot = false)
+			{
+				Protocols = protocols ?? new[] { "http", "https", "ftp" };
+				RequireTld = requireTld;
+				RequireProtocol = requireProtocol;
+				AllowUnderscores = allowUnderscores;
+				AllowTrailingDot = allowTrailingDot;
+
+				HostWhitelist = null;
+				HostBlacklist = null;
+			}
+
+			/// <summary>
+			/// Sets the optional array of whitelist hosts.
+			/// </summary>
+			/// <param name="whitelist">Array of whitelist hosts to use.</param>
+			public void SetWhitelist(string[] whitelist)
+			{
+				HostWhitelist = whitelist;
+			}
+
+			/// <summary>
+			/// Sets the optional array of blacklist hosts.
+			/// </summary>
+			/// <param name="blacklist">Array of blacklist hosts to use.</param>
+			public void SetBlacklist(string[] blacklist)
+			{
+				HostBlacklist = blacklist;
+			}
+		}
+
+		public static bool IsUrl(string url, UrlOptions options = null)
+		{
+			options = options ?? new UrlOptions();
+
+			if (string.IsNullOrWhiteSpace(url) || url.Length >= 2083 || url.StartsWith("mailto:", StringComparison.InvariantCultureIgnoreCase))
+			{
+				return false;
+			}
+
+			var newUrl = string.Empty;
+
+			// parallelize!
+			if (!CheckProtocol(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			url = newUrl;
+
+			//remove #...
+			if (!CheckHash(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			url = newUrl;
+
+			//remove ?...
+			if (!CheckQueryString(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			url = newUrl;
+
+			//remove /...
+			if (!CheckPath(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			url = newUrl;
+
+			if (!CheckAuth(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			url = newUrl;
+
+			if (!CheckHost(url, options, out newUrl))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		private static bool CheckProtocol(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var protocolEndIndex = url.IndexOf("://", StringComparison.InvariantCultureIgnoreCase);
+			if (protocolEndIndex > -1)
+			{
+				var protocol = url.Substring(0, protocolEndIndex);
+				// this is not a one character indexof, so need to account for all three character we were looking for
+				modifiedUrl = url.Substring(protocolEndIndex + 3);
+				return options.Protocols.Contains(protocol);
+			}
+			else
+			{
+				modifiedUrl = url;
+				return !options.RequireProtocol;
+			}
+		}
+
+		private static bool CheckHash(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var hashIndex = url.IndexOf("#", StringComparison.InvariantCultureIgnoreCase);
+			if (hashIndex > -1)
+			{
+				var hashValue = url.Substring(hashIndex + 1);
+				modifiedUrl = url.Substring(0, hashIndex);
+				return !string.IsNullOrWhiteSpace(hashValue);
+			}
+			else
+			{
+				modifiedUrl = url;
+				return true;
+			}
+		}
+
+		private static bool CheckQueryString(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var queryStringIndex = url.IndexOf("?", StringComparison.InvariantCultureIgnoreCase);
+			if (queryStringIndex > -1)
+			{
+				var queryStringValue = url.Substring(queryStringIndex + 1);
+				modifiedUrl = url.Substring(0, queryStringIndex);
+				return !string.IsNullOrWhiteSpace(queryStringValue);
+			}
+			else
+			{
+				modifiedUrl = url;
+				return true;
+			}
+		}
+
+		private static bool CheckPath(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var pathIndex = url.IndexOf("/", StringComparison.InvariantCultureIgnoreCase);
+			if (pathIndex > -1)
+			{
+				var queryStringValue = url.Substring(pathIndex + 1);
+				modifiedUrl = url.Substring(0, pathIndex);
+				if (string.IsNullOrEmpty(queryStringValue))
+				{
+					return true;
+				}
+				else
+				{
+					return !queryStringValue.Contains(" ");
+				}
+				//return !string.IsNullOrWhiteSpace(queryStringValue);
+			}
+			else
+			{
+				modifiedUrl = url;
+				return true;
+			}
+		}
+
+		private static bool CheckAuth(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var authIndex = url.IndexOf("@", StringComparison.InvariantCultureIgnoreCase);
+			modifiedUrl = url;
+			if (authIndex > -1)
+			{
+				var authValue = url.Substring(0, authIndex);
+				var colonIndex = authValue.IndexOf(":", StringComparison.InvariantCultureIgnoreCase);
+				if (colonIndex > -1)
+				{
+					var user = authValue.Substring(0, colonIndex);
+					var pass = authValue.Substring(colonIndex + 1);
+					return !string.IsNullOrWhiteSpace(user) && !string.IsNullOrWhiteSpace(pass);
+				}
+				return true;
+			}
+			else
+			{
+				return true;
+			}
+		}
+
+		private static bool CheckHost(string url, UrlOptions options, out string modifiedUrl)
+		{
+			var atIndex = url.IndexOf("@", StringComparison.InvariantCultureIgnoreCase);
+			//if atIndex is -1, then we'll just get the whole substring
+			var hostName = url.Substring(atIndex+1);
+			var colonIndex = hostName.IndexOf(":", StringComparison.InvariantCultureIgnoreCase);
+			var host = string.Empty;
+
+			// don't care about modifiedUrl here
+			modifiedUrl = url;
+
+			if (colonIndex == -1)
+			{
+				host = hostName;
+			}
+			else
+			{
+				host = hostName.Substring(0, colonIndex);
+				var port = -1;
+				Int32.TryParse(hostName.Substring(colonIndex + 1), out port);
+				if (port <= 0 || port > 65535)
+				{
+					return false;
+				}
+			}
+
+			var isIp = Validator.IsIp(host, IpVersion.Four) || Validator.IsIp(host, IpVersion.Six);
+			var isFqdn = Validator.IsFqdn(host);
+
+			if (!isIp && !isFqdn &&
+			    !string.Equals(host, "localhost", StringComparison.InvariantCultureIgnoreCase))
+			{
+				return false;
+			}
+
+			if (options.HostWhitelist != null && !options.HostWhitelist.Contains(host))
+			{
+				return false;
+			}
+
+			if (options.HostBlacklist != null && !options.HostBlacklist.Contains(host))
+			{
+				return false;
+			}
+
+			return true;
+		}
+	}
+}

--- a/Validator/IsUrl.cs
+++ b/Validator/IsUrl.cs
@@ -112,7 +112,7 @@ namespace Validator
 		{
 			options = options ?? new UrlOptions();
 
-			if (string.IsNullOrWhiteSpace(url) || url.Length >= 2083 || url.StartsWith("mailto:", StringComparison.InvariantCultureIgnoreCase))
+			if (string.IsNullOrEmpty(url) || url.Length >= 2083 || url.StartsWith("mailto:", StringComparison.InvariantCultureIgnoreCase))
 			{
 				return false;
 			}
@@ -185,7 +185,7 @@ namespace Validator
 			{
 				var hashValue = url.Substring(hashIndex + 1);
 				output.NewUrl = url.Substring(0, hashIndex);
-				output.IsValid = !string.IsNullOrWhiteSpace(hashValue);
+				output.IsValid = !string.IsNullOrEmpty(hashValue);
 			}
 			else
 			{
@@ -210,7 +210,7 @@ namespace Validator
 			{
 				var queryStringValue = url.Substring(queryStringIndex + 1);
 				output.NewUrl = url.Substring(0, queryStringIndex);
-				output.IsValid = !string.IsNullOrWhiteSpace(queryStringValue);
+				output.IsValid = !string.IsNullOrEmpty(queryStringValue);
 			}
 			else
 			{

--- a/Validator/IsUrl.cs
+++ b/Validator/IsUrl.cs
@@ -87,12 +87,27 @@ namespace Validator
 			}
 		}
 
+		/// <summary>
+		/// Struct to hold the two pieces of data needed for each Url check sub-function.
+		/// </summary>
 		private struct CheckOutput
 		{
+			/// <summary>
+			/// Whether or not the prospective Url met the criteria for the given function.
+			/// </summary>
 			public bool IsValid;
+			/// <summary>
+			/// The modified Url to use from this point forward.
+			/// </summary>
 			public string NewUrl;
 		}
 
+		/// <summary>
+		/// Determines whether the given string value, <paramref name="url"/>, qualifies as a Url.
+		/// </summary>
+		/// <param name="url">Value to check.</param>
+		/// <param name="options">Options to consider.</param>
+		/// <returns>True if a Url, false otherwise.</returns>
 		public static bool IsUrl(string url, UrlOptions options = null)
 		{
 			options = options ?? new UrlOptions();
@@ -103,6 +118,7 @@ namespace Validator
 			}
 
 			var output = new CheckOutput();
+			// i purposely structured each of these "check" methods the same way so this list of Funcs works.
 			var checkFunctions = new List<Func<string, UrlOptions, CheckOutput>>
 			{
 				CheckProtocol,
@@ -113,6 +129,9 @@ namespace Validator
 				CheckHost
 			};
 
+			// Mimicking the source validator.js means we are monkeying with the url value in many of these functions
+			// as we trim down the url string to verify. In other words, most of these methods remove the portion of the string that they validate
+			// only leaving behind that which has yet to be validated.
 			foreach (var f in checkFunctions)
 			{
 				output = f(url, options);
@@ -126,6 +145,12 @@ namespace Validator
 			return output.IsValid;
 		}
 
+		/// <summary>
+		/// Checks the url string for protocol violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Specifically, this will conditionally check the RequireProtocol option.</param>
+		/// <returns>True if it meets the protocol standards, false otherwise.</returns>
 		private static CheckOutput CheckProtocol(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -146,6 +171,12 @@ namespace Validator
 			return output;
 		}
 
+		/// <summary>
+		/// Checks the url string for hash violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Ignored.</param>
+		/// <returns>True if it meets the hash standards, false otherwise.</returns>
 		private static CheckOutput CheckHash(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -165,6 +196,12 @@ namespace Validator
 			return output;
 		}
 
+		/// <summary>
+		/// Checks the url string for query string violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Ignored.</param>
+		/// <returns>True if it meets the query string standards, false otherwise.</returns>
 		private static CheckOutput CheckQueryString(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -184,6 +221,12 @@ namespace Validator
 			return output;
 		}
 
+		/// <summary>
+		/// Checks the url string for path violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Ignored.</param>
+		/// <returns>True if it meets the path standards, false otherwise.</returns>
 		private static CheckOutput CheckPath(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -210,6 +253,12 @@ namespace Validator
 			return output;
 		}
 
+		/// <summary>
+		/// Checks the url string for authentication violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Ignored.</param>
+		/// <returns>True if it meets the authorization standards, false otherwise.</returns>
 		private static CheckOutput CheckAuth(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -223,7 +272,7 @@ namespace Validator
 				{
 					var user = authValue.Substring(0, colonIndex);
 					var pass = authValue.Substring(colonIndex + 1);
-					output.IsValid = !string.IsNullOrWhiteSpace(user) && !string.IsNullOrWhiteSpace(pass);
+					output.IsValid = !string.IsNullOrEmpty(user) && !string.IsNullOrEmpty(pass);
 				}
 				else
 				{
@@ -238,6 +287,12 @@ namespace Validator
 			return output;
 		}
 
+		/// <summary>
+		/// Checks the url string for host violations.
+		/// </summary>
+		/// <param name="url">The url to check.</param>
+		/// <param name="options">The options to consider. Specifically, it will check white and blaclist entries, if available.</param>
+		/// <returns>True if it meets the host standards, false otherwise.</returns>
 		private static CheckOutput CheckHost(string url, UrlOptions options)
 		{
 			var output = new CheckOutput();
@@ -247,8 +302,8 @@ namespace Validator
 			var colonIndex = hostName.IndexOf(":", StringComparison.InvariantCultureIgnoreCase);
 			var host = string.Empty;
 
-			// don't care about modifiedUrl here
-			output.NewUrl = url;
+			// don't care about modifiedUrl here since this is the last method and there's nothing left to check.
+			output.NewUrl = string.Empty;
 
 			if (colonIndex == -1)
 			{
@@ -266,6 +321,7 @@ namespace Validator
 				}
 			}
 
+			// broke these out from the below if statement simply for readability
 			var isIp = Validator.IsIp(host, IpVersion.Four) || Validator.IsIp(host, IpVersion.Six);
 			var isFqdn = Validator.IsFqdn(host);
 

--- a/Validator/Validator.cs
+++ b/Validator/Validator.cs
@@ -186,16 +186,6 @@ namespace Validator
             return input.Contains(element);
         }
 
-        public static bool IsUrl(string url)
-        {
-            Uri uri = null;
-            if (!Uri.TryCreate(url, UriKind.Absolute, out uri) || null == uri)
-            {
-                return false; //Invalid URL
-            }
-            return true;
-        }
-
         public static bool Matches(string input, string pattern, RegexOptions options = RegexOptions.None)
         {
             return Regex.IsMatch(input, pattern, options);

--- a/Validator/Validator.cs
+++ b/Validator/Validator.cs
@@ -98,19 +98,23 @@ namespace Validator
 
         public static bool IsIp(string input, IpVersion version)
         {
-            IPAddress address;
-            if (IPAddress.TryParse(input, out address))
-            {
-                if (address.AddressFamily == AddressFamily.InterNetwork && version == IpVersion.Four)
-                {
-                    return true;
-                }
-                if (address.AddressFamily == AddressFamily.InterNetworkV6 && version == IpVersion.Six)
-                {
-                    return true;
-                }
-            }
-            return false;
+	        const string ipv4MaybePattern = @"^(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)\.(\d?\d?\d)$";
+			const string ipv6Pattern = @"^::|^::1|^([a-fA-F0-9]{1,4}::?){1,7}([a-fA-F0-9]{1,4})$";
+
+	        if (version == IpVersion.Four)
+	        {
+				if (!Validator.Matches(input, ipv4MaybePattern))
+				{
+					return false;
+				}
+
+		        var parts = input.Split('.').Select(p => Convert.ToInt32(p));
+		        return parts.Max() <= 255;
+	        }
+	        else
+	        {
+		        return Validator.Matches(input, ipv6Pattern);
+	        }
         }
 
         public static bool IsEmail(string input)

--- a/Validator/Validator.csproj
+++ b/Validator/Validator.csproj
@@ -50,6 +50,7 @@
     <Compile Include="IsIsbn.cs" />
     <Compile Include="IsMobilePhone.cs" />
     <Compile Include="IsNumeric.cs" />
+    <Compile Include="IsUrl.cs" />
     <Compile Include="IsUuid.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UuidVersion.cs" />


### PR DESCRIPTION
I've reworked `IsUrl()` to address the `IsUrl2()` tests mentioned in #6 but that has exposed some other issues in the regular `IsUrl()` test method, namely:
* `IsIp()` currently will return true for a value of "01" due to the underlying behavior of `System.Net.IPAddress`
* `IsFqdn()` returns false for "Microsoft.com"
* "abc@xyz.com" returns true unexpectedly, but from what I can tell, the source validator.js would do the same (I don't have time right now to download/build/run those tests and that test value isn't included there)

I may have time tomorrow night to rework `IsIp()` to more closely match the source JS implementation, but I'm not sure what to do about the other two issues.